### PR TITLE
Fix wrong path when getScreenshotDimension

### DIFF
--- a/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsSaver.scala
+++ b/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsSaver.scala
@@ -69,7 +69,7 @@ class ScreenshotsSaver {
       shotFolder: ShotFolder,
       screenshot: Screenshot
   ): Dimension = {
-    val screenshotPath = shotFolder.screenshotsFolder() + screenshot.name + ".png"
+    val screenshotPath = shotFolder.pulledScreenshotsFolder() + screenshot.name + ".png"
     val image          = Image.fromFile(new File(screenshotPath))
     Dimension(image.width, image.height)
   }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://github.com/pedrovgs/Shot/issues/267
* **Related pull-request:** https://github.com/pedrovgs/Shot/pull/259/files#diff-453c09c8197e70a1c6195f40e55c1e4f8c1fd58f2eab38738a0abf0567059253L81

### :tophat: What is the goal?

When we try to record compose screenshot. `ScreenshotsSaver#getScreenshotDimension` is not looking to the good path (see Related pull-request)

### How can it be tested?
cf. Issue : If I clone the repo, delete the shot-consumer-compose/screenshots folder and run ./gradlew executeScreenshotTests -Precord on shot-consumer-compose