### PR TITLE
[ISSUE-244] Fixed error with existing files in pulled screenshot folder

### DIFF
--- a/core/src/main/scala/com/karumi/shot/Shot.scala
+++ b/core/src/main/scala/com/karumi/shot/Shot.scala
@@ -39,9 +39,7 @@ class Shot(
     pullScreenshots(appId, shotFolder)
   }
 
-  def recordScreenshots(
-      appId: AppId,
-      shotFolder: ShotFolder): Unit = {
+  def recordScreenshots(appId: AppId, shotFolder: ShotFolder): Unit = {
     console.show("💾  Saving screenshots.")
     moveComposeScreenshotsToRegularScreenshotsFolder(shotFolder)
     val composeScreenshotSuite = recordComposeScreenshots(shotFolder)

--- a/core/src/main/scala/com/karumi/shot/Shot.scala
+++ b/core/src/main/scala/com/karumi/shot/Shot.scala
@@ -5,7 +5,11 @@ import com.karumi.shot.domain._
 import com.karumi.shot.domain.model.{AppId, FilePath, Folder, ScreenshotsSuite}
 import com.karumi.shot.json.ScreenshotsComposeSuiteJsonParser
 import com.karumi.shot.reports.{ConsoleReporter, ExecutionReporter}
-import com.karumi.shot.screenshots.{ScreenshotsComparator, ScreenshotsDiffGenerator, ScreenshotsSaver}
+import com.karumi.shot.screenshots.{
+  ScreenshotsComparator,
+  ScreenshotsDiffGenerator,
+  ScreenshotsSaver
+}
 import com.karumi.shot.system.EnvVars
 import com.karumi.shot.ui.Console
 import com.karumi.shot.xml.ScreenshotsSuiteXmlParser._

--- a/core/src/main/scala/com/karumi/shot/domain/ShotFolder.scala
+++ b/core/src/main/scala/com/karumi/shot/domain/ShotFolder.scala
@@ -7,25 +7,26 @@ case class ShotFolder(
     private val buildFolderPath: FilePath,
     private val buildType: String,
     private val flavor: Option[String],
-    private val directorySuffix: Option[String]
+    private val directorySuffix: Option[String],
+    private val separator: String
 ) {
-
+  
   private def pathSuffix(): String = {
-    s"${flavor.fold("") { s => s"$s/" }}" +
-      s"$buildType/" +
-      s"${directorySuffix.fold("") { s => s"$s/" }}"
+    s"${flavor.fold("") { s => s"$s$separator" }}" +
+      s"$buildType$separator" +
+      s"${directorySuffix.fold("") { s => s"$s$separator" }}"
   }
 
   def screenshotsFolder(): FilePath = {
-    s"${projectFolderPath}/screenshots/" + pathSuffix()
+    s"${projectFolderPath}${separator}screenshots$separator" + pathSuffix()
   }
 
   def pulledScreenshotsFolder(): FilePath = {
-    s"${screenshotsFolder()}screenshots-default/"
+    s"${screenshotsFolder()}screenshots-default$separator"
   }
 
   def pulledComposeScreenshotsFolder(): FilePath = {
-    s"${screenshotsFolder()}screenshots-compose-default/"
+    s"${screenshotsFolder()}screenshots-compose-default$separator"
   }
 
   def metadataFile(): FilePath = {
@@ -37,16 +38,17 @@ case class ShotFolder(
   }
 
   def reportFolder(): FilePath = {
-    s"${buildFolderPath}/reports/shot/${pathSuffix()}"
+    s"${buildFolderPath}${separator}reports${separator}shot$separator${pathSuffix()}"
   }
 
   def verificationReportFolder(): String = {
-    s"${reportFolder()}verification/"
+    s"${reportFolder()}verification$separator"
   }
 
   def recordingReportFolder(): String = {
-    s"${reportFolder()}record/"
+    s"${reportFolder()}record$separator"
   }
 
-  def screenshotsTemporalBuildPath(): FilePath = s"$buildFolderPath/tmp/shot/screenshot/"
+  def screenshotsTemporalBuildPath(): FilePath =
+    s"$buildFolderPath${separator}tmp${separator}shot${separator}screenshot$separator"
 }

--- a/core/src/main/scala/com/karumi/shot/domain/ShotFolder.scala
+++ b/core/src/main/scala/com/karumi/shot/domain/ShotFolder.scala
@@ -10,7 +10,7 @@ case class ShotFolder(
     private val directorySuffix: Option[String],
     private val separator: String
 ) {
-  
+
   private def pathSuffix(): String = {
     s"${flavor.fold("") { s => s"$s$separator" }}" +
       s"$buildType$separator" +

--- a/core/src/test/scala/com/karumi/shot/ShotSpec.scala
+++ b/core/src/test/scala/com/karumi/shot/ShotSpec.scala
@@ -186,8 +186,6 @@ class ShotSpec
       "🤔 We couldn't find any screenshot. Did you configure Shot properly and added your tests to your project? https://github.com/Karumi/Shot/#getting-started"
     )
 
-    shot.recordScreenshots(
-      appId,
-      ProjectFolderMother.anyShotFolder)
+    shot.recordScreenshots(appId, ProjectFolderMother.anyShotFolder)
   }
 }

--- a/core/src/test/scala/com/karumi/shot/ShotSpec.scala
+++ b/core/src/test/scala/com/karumi/shot/ShotSpec.scala
@@ -188,8 +188,6 @@ class ShotSpec
 
     shot.recordScreenshots(
       appId,
-      ProjectFolderMother.anyShotFolder,
-      ProjectNameMother.anyProjectName
-    )
+      ProjectFolderMother.anyShotFolder)
   }
 }

--- a/core/src/test/scala/com/karumi/shot/domain/ShotFolderSpec.scala
+++ b/core/src/test/scala/com/karumi/shot/domain/ShotFolderSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 class ShotFolderSpec extends AnyFunSpec {
 
   describe("Shot folder") {
-    val shotFolder = ShotFolder("shot", "shot/build", "debug", None, None)
+    val shotFolder = ShotFolder("shot", "shot/build", "debug", None, None, "/")
 
     it("should have screenshots folder") {
       shotFolder.screenshotsFolder() shouldBe s"shot/screenshots/debug/"
@@ -33,7 +33,7 @@ class ShotFolderSpec extends AnyFunSpec {
   }
 
   describe("Product Flavor") {
-    val shotFolder = ShotFolder("shot", "shot/build", "debug", Some("green"), None)
+    val shotFolder = ShotFolder("shot", "shot/build", "debug", Some("green"), None, "/")
 
     it("should have screenshots folder") {
       shotFolder.screenshotsFolder() shouldBe s"shot/screenshots/green/debug/"
@@ -59,7 +59,7 @@ class ShotFolderSpec extends AnyFunSpec {
   }
 
   describe("Directory Suffix") {
-    val shotFolder = ShotFolder("shot", "shot/build", "debug", None, Some("Api26"))
+    val shotFolder = ShotFolder("shot", "shot/build", "debug", None, Some("Api26"), "/")
 
     it("should have screenshots folder") {
       shotFolder.screenshotsFolder() shouldBe s"shot/screenshots/debug/Api26/"
@@ -85,7 +85,7 @@ class ShotFolderSpec extends AnyFunSpec {
   }
 
   describe("Product Flavor & Directory Suffix") {
-    val shotFolder = ShotFolder("shot", "shot/build", "debug", Some("green"), Some("Api26"))
+    val shotFolder = ShotFolder("shot", "shot/build", "debug", Some("green"), Some("Api26"), "/")
 
     it("should have screenshots folder") {
       shotFolder.screenshotsFolder() shouldBe s"shot/screenshots/green/debug/Api26/"

--- a/core/src/test/scala/com/karumi/shot/mothers/ProjectFolderMother.scala
+++ b/core/src/test/scala/com/karumi/shot/mothers/ProjectFolderMother.scala
@@ -9,13 +9,15 @@ object ProjectFolderMother {
   val anyBuildType       = "debug"
   val anyFlavor          = "green"
   val anyDirectorySuffix = "Api26"
+  val anySeparator = "/"
 
   val anyShotFolder: ShotFolder = ShotFolder(
     anyProjectFolder,
     anyBuildFolder,
     anyBuildType,
     Some(anyFlavor),
-    Some(anyDirectorySuffix)
+    Some(anyDirectorySuffix),
+    anySeparator
   )
 
 }

--- a/core/src/test/scala/com/karumi/shot/mothers/ProjectFolderMother.scala
+++ b/core/src/test/scala/com/karumi/shot/mothers/ProjectFolderMother.scala
@@ -9,7 +9,7 @@ object ProjectFolderMother {
   val anyBuildType       = "debug"
   val anyFlavor          = "green"
   val anyDirectorySuffix = "Api26"
-  val anySeparator = "/"
+  val anySeparator       = "/"
 
   val anyShotFolder: ShotFolder = ShotFolder(
     anyProjectFolder,

--- a/shot/src/main/scala/com/karumi/shot/tasks/Tasks.scala
+++ b/shot/src/main/scala/com/karumi/shot/tasks/Tasks.scala
@@ -5,7 +5,11 @@ import com.karumi.shot.android.Adb
 import com.karumi.shot.base64.Base64Encoder
 import com.karumi.shot.domain.ShotFolder
 import com.karumi.shot.reports.{ConsoleReporter, ExecutionReporter}
-import com.karumi.shot.screenshots.{ScreenshotsComparator, ScreenshotsDiffGenerator, ScreenshotsSaver}
+import com.karumi.shot.screenshots.{
+  ScreenshotsComparator,
+  ScreenshotsDiffGenerator,
+  ScreenshotsSaver
+}
 import com.karumi.shot.system.EnvVars
 import com.karumi.shot.ui.Console
 import com.karumi.shot.{Files, Shot, ShotExtension}
@@ -81,9 +85,7 @@ class ExecuteScreenshotTests extends ShotTask {
       .getByType[ShotExtension](classOf[ShotExtension])
       .showOnlyFailingTestsInReports
     if (recordScreenshots) {
-      shot.recordScreenshots(
-        appId,
-        shotFolder)
+      shot.recordScreenshots(appId, shotFolder)
     } else {
       val result = shot.verifyScreenshots(
         appId,

--- a/shot/src/main/scala/com/karumi/shot/tasks/Tasks.scala
+++ b/shot/src/main/scala/com/karumi/shot/tasks/Tasks.scala
@@ -5,16 +5,14 @@ import com.karumi.shot.android.Adb
 import com.karumi.shot.base64.Base64Encoder
 import com.karumi.shot.domain.ShotFolder
 import com.karumi.shot.reports.{ConsoleReporter, ExecutionReporter}
-import com.karumi.shot.screenshots.{
-  ScreenshotsComparator,
-  ScreenshotsDiffGenerator,
-  ScreenshotsSaver
-}
+import com.karumi.shot.screenshots.{ScreenshotsComparator, ScreenshotsDiffGenerator, ScreenshotsSaver}
 import com.karumi.shot.system.EnvVars
 import com.karumi.shot.ui.Console
 import com.karumi.shot.{Files, Shot, ShotExtension}
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.{DefaultTask, GradleException}
+
+import java.io.File
 
 abstract class ShotTask extends DefaultTask {
   var appId: String          = _
@@ -44,7 +42,8 @@ abstract class ShotTask extends DefaultTask {
       buildType.getName,
       flavor,
       if (project.hasProperty("directorySuffix")) Some(project.property("directorySuffix").toString)
-      else None
+      else None,
+      File.separator
     )
   }
 
@@ -84,9 +83,7 @@ class ExecuteScreenshotTests extends ShotTask {
     if (recordScreenshots) {
       shot.recordScreenshots(
         appId,
-        shotFolder,
-        project.getName
-      )
+        shotFolder)
     } else {
       val result = shot.verifyScreenshots(
         appId,


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #244

### :tophat: What is the goal?

Fixing error with existing files in pulled screenshot folder for regular and compose tests.

### How is it being implemented?

- Added removing `pulledScreenshotFolder` before downloading screenshots
- Removing both regular and compose `pulledScreenshotFolder`
- Added configuration of separation char in `ShotFolder` class

### How can it be tested?

- [x] **Use case 1:** Run test for shot
  - [x] `gradlew test`
- [x] **Use case 2:** Run in all shot-consumer-*
  - [x] `gradlew publishToMavenLocal`
  - [x] `gradlew executeScreenshot -Precord`
  - [x] `gradlew executeScreenshot`