### PR TITLE
Fix Compose JSON parsing

### DIFF
--- a/core/src/main/scala/com/karumi/shot/Shot.scala
+++ b/core/src/main/scala/com/karumi/shot/Shot.scala
@@ -279,7 +279,7 @@ class Shot(
         )
       val screenshotSuite = metadataFiles.flatMap { metadataFilePath =>
         val metadataFileContent = files.read(metadataFilePath.getAbsolutePath)
-        ScreenshotsComposeSuiteJsonParser.parseScreenshots(
+        ScreenshotsComposeSuiteJsonParser.parseScreenshotSuite(
           metadataFileContent,
           shotFolder.screenshotsFolder(),
           shotFolder.pulledScreenshotsFolder(),

--- a/core/src/main/scala/com/karumi/shot/json/ScreenshotsComposeSuiteJsonParser.scala
+++ b/core/src/main/scala/com/karumi/shot/json/ScreenshotsComposeSuiteJsonParser.scala
@@ -1,5 +1,6 @@
 package com.karumi.shot.json
 
+import com.drew.metadata.Metadata
 import com.karumi.shot.domain.{Dimension, Screenshot}
 import com.karumi.shot.domain.model.{Folder, ScreenshotsSuite}
 import org.json4s._
@@ -7,15 +8,7 @@ import org.json4s.native.JsonMethods._
 
 object ScreenshotsComposeSuiteJsonParser {
 
-  def parseScreenshot(jsonNode: JsonAST.JValue): ComposeScreenshot = {
-    val JString(name)          = jsonNode \ "name"
-    val JString(testClassName) = jsonNode \ "testClassName"
-    val JString(testName)      = jsonNode \ "testName"
-
-    ComposeScreenshot(name, testClassName, testName)
-  }
-
-  def parseScreenshots(
+  def parseScreenshotSuite(
       metadataJson: String,
       screenshotsFolder: Folder,
       temporalScreenshotsFolder: Folder,
@@ -23,26 +16,64 @@ object ScreenshotsComposeSuiteJsonParser {
   ): ScreenshotsSuite = {
     implicit val formats: DefaultFormats.type = DefaultFormats
 
-    val json                            = parse(metadataJson)
-    val JObject(composeScreenshotSuite) = json
-    val JArray(composeScreenshots)      = json \ "screenshots"
+    val json = parse(metadataJson)
 
-    composeScreenshots.map(parseScreenshot).map { screenshot =>
-      val name = screenshot.name
-      Screenshot(
-        name = name,
-        recordedScreenshotPath = screenshotsFolder + name + ".png",
-        temporalScreenshotPath = screenshotsTemporalBuildPath + "/" + name + ".png",
-        testClass = screenshot.testClassName,
-        testName = screenshot.testName,
-        tilesDimension = Dimension(0, 0),
-        viewHierarchy = "",
-        absoluteFileNames = Seq(),
-        relativeFileNames = Seq(),
-        recordedPartsPaths = Seq(temporalScreenshotsFolder + "/" + name + ".png"),
-        screenshotDimension = Dimension(0, 0)
+    parseScreenshots(
+      json,
+      screenshotsFolder,
+      temporalScreenshotsFolder,
+      screenshotsTemporalBuildPath
+    )
+  }
+
+  private def parseScreenshots(
+      json: JValue,
+      screenshotsFolder: Folder,
+      temporalScreenshotsFolder: Folder,
+      screenshotsTemporalBuildPath: Folder
+  ): ScreenshotsSuite = {
+    val JArray(composeScreenshots) = json \ "screenshots"
+
+    composeScreenshots
+      .map(parseScreenshot)
+      .map(
+        mapComposeScreenshot(
+          _,
+          screenshotsFolder,
+          temporalScreenshotsFolder,
+          screenshotsTemporalBuildPath
+        )
       )
-    }
+  }
+
+  private def parseScreenshot(jsonNode: JsonAST.JValue): ComposeScreenshot = {
+    val JString(name)          = jsonNode \ "name"
+    val JString(testClassName) = jsonNode \ "testClassName"
+    val JString(testName)      = jsonNode \ "testName"
+
+    ComposeScreenshot(name, testClassName, testName)
+  }
+
+  private def mapComposeScreenshot(
+      screenshot: ComposeScreenshot,
+      screenshotsFolder: Folder,
+      temporalScreenshotsFolder: Folder,
+      screenshotsTemporalBuildPath: Folder
+  ): Screenshot = {
+    val name = screenshot.name
+    Screenshot(
+      name = name,
+      recordedScreenshotPath = screenshotsFolder + name + ".png",
+      temporalScreenshotPath = screenshotsTemporalBuildPath + "/" + name + ".png",
+      testClass = screenshot.testClassName,
+      testName = screenshot.testName,
+      tilesDimension = Dimension(0, 0),
+      viewHierarchy = "",
+      absoluteFileNames = Seq(),
+      relativeFileNames = Seq(),
+      recordedPartsPaths = Seq(temporalScreenshotsFolder + "/" + name + ".png"),
+      screenshotDimension = Dimension(0, 0)
+    )
   }
 }
 

--- a/core/src/main/scala/com/karumi/shot/json/ScreenshotsComposeSuiteJsonParser.scala
+++ b/core/src/main/scala/com/karumi/shot/json/ScreenshotsComposeSuiteJsonParser.scala
@@ -3,18 +3,31 @@ package com.karumi.shot.json
 import com.karumi.shot.domain.{Dimension, Screenshot}
 import com.karumi.shot.domain.model.{Folder, ScreenshotsSuite}
 import org.json4s._
-import org.json4s.jackson.JsonMethods._
+import org.json4s.native.JsonMethods._
 
 object ScreenshotsComposeSuiteJsonParser {
+
+  def parseScreenshot(jsonNode: JsonAST.JValue): ComposeScreenshot = {
+    val JString(name)          = jsonNode \ "name"
+    val JString(testClassName) = jsonNode \ "testClassName"
+    val JString(testName)      = jsonNode \ "testName"
+
+    ComposeScreenshot(name, testClassName, testName)
+  }
+
   def parseScreenshots(
-      json: String,
+      metadataJson: String,
       screenshotsFolder: Folder,
       temporalScreenshotsFolder: Folder,
       screenshotsTemporalBuildPath: Folder
   ): ScreenshotsSuite = {
     implicit val formats: DefaultFormats.type = DefaultFormats
-    val composeSuite                          = parse(json).extract[ComposeScreenshotSuite]
-    composeSuite.screenshots.map { screenshot =>
+
+    val json                            = parse(metadataJson)
+    val JObject(composeScreenshotSuite) = json
+    val JArray(composeScreenshots)      = json \ "screenshots"
+
+    composeScreenshots.map(parseScreenshot).map { screenshot =>
       val name = screenshot.name
       Screenshot(
         name = name,

--- a/core/src/test/resources/screenshots-metadata/compose-metadata.json
+++ b/core/src/test/resources/screenshots-metadata/compose-metadata.json
@@ -1,0 +1,19 @@
+{
+  "screenshots": [
+    {
+      "name": "com.example.test.ButtonTest_test1",
+      "testClassName": "com.example.test.ButtonTest",
+      "testName": "test1"
+    },
+    {
+      "name": "com.example.test.ButtonTest_test2",
+      "testClassName": "com.example.test.ButtonTest",
+      "testName": "test2"
+    },
+    {
+      "name": "com.example.test.ButtonTest_test3",
+      "testClassName": "com.example.test.ButtonTest",
+      "testName": "test3"
+    }
+  ]
+}

--- a/core/src/test/resources/screenshots-metadata/empty-compose-screenshots-metadata.json
+++ b/core/src/test/resources/screenshots-metadata/empty-compose-screenshots-metadata.json
@@ -1,0 +1,3 @@
+{
+  "screenshots": []
+}

--- a/core/src/test/scala/com/karumi/shot/json/ScreenshotsComposeSuiteJsonParserSpec.scala
+++ b/core/src/test/scala/com/karumi/shot/json/ScreenshotsComposeSuiteJsonParserSpec.scala
@@ -1,0 +1,103 @@
+package com.karumi.shot.json
+
+import com.karumi.shot.Resources
+import com.karumi.shot.domain.{Dimension, Screenshot}
+import com.karumi.shot.json.ScreenshotsComposeSuiteJsonParser.{
+  parseScreenshotSuite,
+  parseScreenshots
+}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+import scala.Seq
+
+class ScreenshotsComposeSuiteJsonParserSpec
+    extends AnyFlatSpec
+    with should.Matchers
+    with Resources {
+  private val anyScreenshotsFolder = "/screenshots/"
+  private val anyTemporalScreenshotsFolder =
+    "/screenshots/screenshots-default/"
+  private val anyScreenshotsTemporalBuildPath =
+    "/build/tmp/shot/screenshots"
+
+  private val testClassName = "com.example.test.ButtonTest"
+  private val testName1     = "test1"
+  private val testName2     = "test2"
+  private val testName3     = "test3"
+  private val name1         = s"${testClassName}_${testName1}"
+  private val name2         = s"${testClassName}_${testName2}"
+  private val name3         = s"${testClassName}_${testName3}"
+
+  private val expectedScreenshots = Seq(
+    Screenshot(
+      name = name1,
+      recordedScreenshotPath = s"$anyScreenshotsFolder$name1.png",
+      temporalScreenshotPath = s"$anyScreenshotsTemporalBuildPath/$name1.png",
+      testClass = testClassName,
+      testName = testName1,
+      tilesDimension = Dimension(0, 0),
+      viewHierarchy = "",
+      absoluteFileNames = Seq(),
+      relativeFileNames = Seq(),
+      recordedPartsPaths = Seq(s"$anyTemporalScreenshotsFolder/$name1.png"),
+      screenshotDimension = Dimension(0, 0)
+    ),
+    Screenshot(
+      name = name2,
+      recordedScreenshotPath = s"$anyScreenshotsFolder$name2.png",
+      temporalScreenshotPath = s"$anyScreenshotsTemporalBuildPath/$name2.png",
+      testClass = testClassName,
+      testName = testName2,
+      tilesDimension = Dimension(0, 0),
+      viewHierarchy = "",
+      absoluteFileNames = Seq(),
+      relativeFileNames = Seq(),
+      recordedPartsPaths = Seq(s"$anyTemporalScreenshotsFolder/$name2.png"),
+      screenshotDimension = Dimension(0, 0)
+    ),
+    Screenshot(
+      name = name3,
+      recordedScreenshotPath = s"$anyScreenshotsFolder$name3.png",
+      temporalScreenshotPath = s"$anyScreenshotsTemporalBuildPath/$name3.png",
+      testClass = testClassName,
+      testName = testName3,
+      tilesDimension = Dimension(0, 0),
+      viewHierarchy = "",
+      absoluteFileNames = Seq(),
+      relativeFileNames = Seq(),
+      recordedPartsPaths = Seq(s"$anyTemporalScreenshotsFolder/$name3.png"),
+      screenshotDimension = Dimension(0, 0)
+    )
+  )
+
+  "ScreenshotsComposeSuiteJsonParser" should "return an empty spec if there are no screenshots" in {
+    val json = testResourceContent("/screenshots-metadata/empty-compose-screenshots-metadata.json")
+
+    val screenshots =
+      parseScreenshotSuite(
+        json,
+        anyScreenshotsFolder,
+        anyTemporalScreenshotsFolder,
+        anyScreenshotsTemporalBuildPath
+      )
+
+    screenshots shouldBe empty
+  }
+
+  it should "parse a regular metadata file" in {
+    val json = testResourceContent("/screenshots-metadata/compose-metadata.json")
+
+    val screenshots =
+      parseScreenshotSuite(
+        json,
+        anyScreenshotsFolder,
+        anyTemporalScreenshotsFolder,
+        anyScreenshotsTemporalBuildPath
+      )
+
+    screenshots.size shouldBe 3
+
+    screenshots should be(expectedScreenshots)
+  }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #274

### :tophat: What is the goal?

Processing of screenshot results on Compose fails because of the issue with Jackson being not able to create a reader to process JSON results. 
This is a workaround to parse those results without help of Jackson.

### How is it being implemented?

Instead of parsing the the `ComposeScreenshotSuite` with the help of Jackson, the manual parsing of AST implemented. This also aligns the parsing process with another implementation flow for legacy view system in `ScreenshotsSuiteJsonParser`, where the manual AST parsing happens.
I also did some refactoring to improve code structure in `ScreenshotsComposeSuiteJsonParser`.

### How can it be tested?

- [ ] **Use case 1:** Added a test case to check mapping of empty screenshots metadata. New `empty-compose-screenshots-metadata.json` resource was added for that.
- [ ] **Use case 2:** Added a test case to check mapping of screenshots metadata. New `compose-metadata.json` resource was added for that.
