### PR TITLE
Indiscriminate version bumps to latest versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,14 +5,14 @@ buildscript {
         google()
     }
 
-    ext.kotlin_version = "1.4.32"
+    ext.kotlin_version = "1.6.10"
 
     dependencies {
         classpath "gradle.plugin.com.github.maiflai:gradle-scalatest:0.31"
         classpath "gradle.plugin.cz.alenkacz:gradle-scalafmt:1.16.2"
-        classpath "com.android.tools.build:gradle:4.1.3"
+        classpath "com.android.tools.build:gradle:7.1.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:10.0.0"
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.15.1'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.18.0'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,8 @@ POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_DEVELOPER_ID=karumi
 POM_DEVELOPER_NAME=Karumi
+
+# Declare we support AndroidX
+android.useAndroidX=true
+
+org.gradle.jvmargs=-Xmx2g

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/shot-android/build.gradle
+++ b/shot-android/build.gradle
@@ -4,12 +4,12 @@ apply plugin: "org.jlleitschuh.gradle.ktlint"
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion 28
+    compileSdk 31
     testOptions.unitTests.includeAndroidResources = true
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 28
+        minSdk 21
+        targetSdk 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "com.karumi.shot.DexOpenerJUnitRunner"
@@ -49,11 +49,11 @@ repositories {
 
 dependencies {
     implementation "com.facebook.testing.screenshot:core:0.14.0"
-    implementation "androidx.test:runner:1.3.0"
-    implementation "androidx.recyclerview:recyclerview:1.2.0"
-    implementation "androidx.test.espresso:espresso-core:3.3.0"
-    implementation "androidx.compose.ui:ui-test-junit4:1.0.0-beta03"
-    implementation "com.google.code.gson:gson:2.8.6"
+    implementation "androidx.test:runner:1.4.0"
+    implementation "androidx.recyclerview:recyclerview:1.2.1"
+    implementation "androidx.test.espresso:espresso-core:3.4.0"
+    implementation "androidx.compose.ui:ui-test-junit4:1.2.0-alpha03"
+    implementation "com.google.code.gson:gson:2.8.7"
 
     // fragment-testing dependency is normally declared for debug (not test) sources,
     // as you'd usually run your FragmentScenario tests only in debug variants.
@@ -61,28 +61,28 @@ dependencies {
     // debugImplementation instead. However it doesn't matter here because we're still only using it
     // for testing purposes. FragmentScenario API is needed to provide waitForFragment() extension.
     //noinspection FragmentGradleConfiguration
-    implementation "androidx.fragment:fragment-testing:1.3.2"
+    implementation "androidx.fragment:fragment-testing:1.4.1"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.mockito:mockito-core:3.9.0"
     testImplementation "com.nhaarman:mockito-kotlin:1.6.0"
-    testImplementation "org.robolectric:robolectric:4.5.1"
-    testImplementation "androidx.test.ext:junit:1.1.2"
-    testImplementation "androidx.test:runner:1.3.0"
-    testImplementation "androidx.test:rules:1.3.0"
-    testImplementation "androidx.test.espresso:espresso-core:3.3.0"
-    testImplementation "androidx.test.espresso:espresso-intents:3.3.0"
-    testImplementation "androidx.test.espresso:espresso-contrib:3.3.0"
+    testImplementation "org.robolectric:robolectric:4.7.3"
+    testImplementation "androidx.test.ext:junit:1.1.3"
+    testImplementation "androidx.test:runner:1.4.0"
+    testImplementation "androidx.test:rules:1.4.0"
+    testImplementation "androidx.test.espresso:espresso-core:3.4.0"
+    testImplementation "androidx.test.espresso:espresso-intents:3.4.0"
+    testImplementation "androidx.test.espresso:espresso-contrib:3.4.0"
 
     androidTestImplementation "com.github.tmurakami:dexopener:2.0.5"
     androidTestImplementation "org.mockito:mockito-android:2.28.2"
     androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
-    androidTestImplementation "androidx.test:runner:1.3.0"
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"
-    androidTestImplementation "androidx.test.espresso:espresso-intents:3.3.0"
-    androidTestImplementation "androidx.test.espresso:espresso-contrib:3.3.0"
-    androidTestImplementation "androidx.test:rules:1.3.0"
-    androidTestImplementation "androidx.test.ext:junit:1.1.2"
+    androidTestImplementation "androidx.test:runner:1.4.0"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.4.0"
+    androidTestImplementation "androidx.test.espresso:espresso-intents:3.4.0"
+    androidTestImplementation "androidx.test.espresso:espresso-contrib:3.4.0"
+    androidTestImplementation "androidx.test:rules:1.4.0"
+    androidTestImplementation "androidx.test.ext:junit:1.1.3"
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {

--- a/shot-consumer-compose/app/build.gradle
+++ b/shot-consumer-compose/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: "shot"
 
 android {
     compileSdk 31
-    buildToolsVersion "30.0.2"
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.karumi.shotconsumercompose"

--- a/shot-consumer-compose/app/build.gradle
+++ b/shot-consumer-compose/app/build.gradle
@@ -5,13 +5,13 @@ plugins {
 apply plugin: "shot"
 
 android {
-    compileSdkVersion 30
+    compileSdk 31
     buildToolsVersion "30.0.2"
 
     defaultConfig {
         applicationId "com.karumi.shotconsumercompose"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdk 30
         versionCode 1
         versionName "1.0"
 

--- a/shot-consumer-flavors/app/build.gradle
+++ b/shot-consumer-flavors/app/build.gradle
@@ -25,7 +25,7 @@ android {
     defaultConfig {
         applicationId "com.karumi"
         minSdkVersion 21
-        compileSdk 31
+        targetSdk 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "com.karumi.TestRunner"

--- a/shot-consumer-flavors/app/build.gradle
+++ b/shot-consumer-flavors/app/build.gradle
@@ -21,11 +21,11 @@ apply plugin: "com.trevjonez.composer"
 apply plugin: "shot"
 
 android {
-    compileSdkVersion 28
+    compileSdk 31
     defaultConfig {
         applicationId "com.karumi"
         minSdkVersion 21
-        targetSdkVersion 28
+        compileSdk 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "com.karumi.TestRunner"

--- a/shot-consumer/app/build.gradle
+++ b/shot-consumer/app/build.gradle
@@ -25,7 +25,7 @@ android {
     defaultConfig {
         applicationId "com.karumi"
         minSdkVersion 21
-        compileSdk 31
+        targetSdk 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "com.karumi.TestRunner"

--- a/shot-consumer/app/build.gradle
+++ b/shot-consumer/app/build.gradle
@@ -21,11 +21,11 @@ apply plugin: "com.trevjonez.composer"
 apply plugin: "shot"
 
 android {
-    compileSdkVersion 28
+    compileSdk 31
     defaultConfig {
         applicationId "com.karumi"
         minSdkVersion 21
-        targetSdkVersion 28
+        compileSdk 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "com.karumi.TestRunner"

--- a/shot-consumer/app2/build.gradle
+++ b/shot-consumer/app2/build.gradle
@@ -25,7 +25,7 @@ android {
     defaultConfig {
         applicationId "com.karumi"
         minSdkVersion 21
-        compileSdk 31
+        targetSdk 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "com.karumi.TestRunner"

--- a/shot-consumer/app2/build.gradle
+++ b/shot-consumer/app2/build.gradle
@@ -21,11 +21,11 @@ apply plugin: "com.trevjonez.composer"
 apply plugin: "shot"
 
 android {
-    compileSdkVersion 28
+    compileSdk 31
     defaultConfig {
         applicationId "com.karumi"
         minSdkVersion 21
-        targetSdkVersion 28
+        compileSdk 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "com.karumi.TestRunner"

--- a/shot-consumer/samplelibrary/build.gradle
+++ b/shot-consumer/samplelibrary/build.gradle
@@ -8,7 +8,7 @@ android {
     defaultConfig {
         testApplicationId "com.karumi.samplelibrary.test.app.id"
         minSdkVersion 21
-        compileSdk 31
+        targetSdk 30
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/shot-consumer/samplelibrary/build.gradle
+++ b/shot-consumer/samplelibrary/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'shot'
 
 android {
-    compileSdkVersion 28
+    compileSdk 31
 
     defaultConfig {
         testApplicationId "com.karumi.samplelibrary.test.app.id"
         minSdkVersion 21
-        targetSdkVersion 28
+        compileSdk 31
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/shot/build.gradle
+++ b/shot/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation gradleApi()
     implementation localGroovy()
     implementation project(':core')
-    compileOnly 'com.android.tools.build:gradle:7.1.0-alpha06'
+    compileOnly 'com.android.tools.build:gradle:7.1.1'
     implementation 'org.scala-lang:scala-library:2.12.13'
 
     testImplementation 'org.scalatest:scalatest_2.12:3.2.6'


### PR DESCRIPTION
**I understand if you don't want to update all dependecies, please close if this is the case.**

### :pushpin: References

https://github.com/pedrovgs/Shot/issues/287

### :tophat: What is the goal?

To build on M1 macbook, but also with latest versions.

My ultimate goal is to test with Wear emulator in my own projects, and because I hit issues I wanted to build Shot locally, and then hit various issues.

### How is it being implemented?

Went through upgrades of depdnencies to latest versions with support for M1.

This also changes targetSdk, which presumably could change behaviour.

### How can it be tested?

CI? Existing tests.
