### PR TITLE
Support configuration cache

### DIFF
--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -180,8 +180,10 @@ class ShotPlugin extends Plugin[Project] {
       task.projectPath = project.getProjectDir.getAbsolutePath
       task.buildPath = project.getBuildDir.getAbsolutePath
       task.shotExtension = project.getExtensions.findByType(classOf[ShotExtension])
-      task.directorySuffix = if (project.hasProperty("directorySuffix")) Some(project.property("directorySuffix").toString)
-      else None
+      task.directorySuffix =
+        if (project.hasProperty("directorySuffix"))
+          Some(project.property("directorySuffix").toString)
+        else None
       task.recordScreenshots = project.hasProperty("record")
       task.printBase64 = project.hasProperty("printBase64")
       task.projectName = project.getName
@@ -195,8 +197,10 @@ class ShotPlugin extends Plugin[Project] {
       task.projectPath = project.getProjectDir.getAbsolutePath
       task.buildPath = project.getBuildDir.getAbsolutePath
       task.shotExtension = project.getExtensions.findByType(classOf[ShotExtension])
-      task.directorySuffix = if (project.hasProperty("directorySuffix")) Some(project.property("directorySuffix").toString)
-      else None
+      task.directorySuffix =
+        if (project.hasProperty("directorySuffix"))
+          Some(project.property("directorySuffix").toString)
+        else None
       task.recordScreenshots = project.hasProperty("record")
       task.printBase64 = project.hasProperty("printBase64")
       task.projectName = project.getName
@@ -213,8 +217,10 @@ class ShotPlugin extends Plugin[Project] {
       task.projectPath = project.getProjectDir.getAbsolutePath
       task.buildPath = project.getBuildDir.getAbsolutePath
       task.shotExtension = project.getExtensions.findByType(classOf[ShotExtension])
-      task.directorySuffix = if (project.hasProperty("directorySuffix")) Some(project.property("directorySuffix").toString)
-      else None
+      task.directorySuffix =
+        if (project.hasProperty("directorySuffix"))
+          Some(project.property("directorySuffix").toString)
+        else None
       task.recordScreenshots = project.hasProperty("record")
       task.printBase64 = project.hasProperty("printBase64")
       task.projectName = project.getName
@@ -230,8 +236,10 @@ class ShotPlugin extends Plugin[Project] {
       task.projectPath = project.getProjectDir.getAbsolutePath
       task.buildPath = project.getBuildDir.getAbsolutePath
       task.shotExtension = project.getExtensions.findByType(classOf[ShotExtension])
-      task.directorySuffix = if (project.hasProperty("directorySuffix")) Some(project.property("directorySuffix").toString)
-      else None
+      task.directorySuffix =
+        if (project.hasProperty("directorySuffix"))
+          Some(project.property("directorySuffix").toString)
+        else None
       task.recordScreenshots = project.hasProperty("record")
       task.printBase64 = project.hasProperty("printBase64")
       task.projectName = project.getName

--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -174,16 +174,32 @@ class ShotPlugin extends Plugin[Project] {
     removeScreenshotsAfterExecution.configure { task =>
       task.setDescription(RemoveScreenshotsTask.description(flavor, buildType))
       task.flavor = flavor
-      task.buildType = buildType
+      task.buildTypeName = buildType.getName
       task.appId = appId
       task.orchestrated = orchestrated
+      task.projectPath = project.getProjectDir.getAbsolutePath
+      task.buildPath = project.getBuildDir.getAbsolutePath
+      task.shotExtension = project.getExtensions.findByType(classOf[ShotExtension])
+      task.directorySuffix = if (project.hasProperty("directorySuffix")) Some(project.property("directorySuffix").toString)
+      else None
+      task.recordScreenshots = project.hasProperty("record")
+      task.printBase64 = project.hasProperty("printBase64")
+      task.projectName = project.getName
     }
     removeScreenshotsBeforeExecution.configure { task =>
       task.setDescription(RemoveScreenshotsTask.description(flavor, buildType))
       task.flavor = flavor
-      task.buildType = buildType
+      task.buildTypeName = buildType.getName
       task.appId = appId
       task.orchestrated = orchestrated
+      task.projectPath = project.getProjectDir.getAbsolutePath
+      task.buildPath = project.getBuildDir.getAbsolutePath
+      task.shotExtension = project.getExtensions.findByType(classOf[ShotExtension])
+      task.directorySuffix = if (project.hasProperty("directorySuffix")) Some(project.property("directorySuffix").toString)
+      else None
+      task.recordScreenshots = project.hasProperty("record")
+      task.printBase64 = project.hasProperty("printBase64")
+      task.projectName = project.getName
     }
 
     val downloadScreenshots = tasks
@@ -191,18 +207,34 @@ class ShotPlugin extends Plugin[Project] {
     downloadScreenshots.configure { task =>
       task.setDescription(DownloadScreenshotsTask.description(flavor, buildType))
       task.flavor = flavor
-      task.buildType = buildType
+      task.buildTypeName = buildType.getName
       task.appId = appId
       task.orchestrated = orchestrated
+      task.projectPath = project.getProjectDir.getAbsolutePath
+      task.buildPath = project.getBuildDir.getAbsolutePath
+      task.shotExtension = project.getExtensions.findByType(classOf[ShotExtension])
+      task.directorySuffix = if (project.hasProperty("directorySuffix")) Some(project.property("directorySuffix").toString)
+      else None
+      task.recordScreenshots = project.hasProperty("record")
+      task.printBase64 = project.hasProperty("printBase64")
+      task.projectName = project.getName
     }
     val executeScreenshot = tasks
       .register(ExecuteScreenshotTests.name(flavor, buildType), classOf[ExecuteScreenshotTests])
     executeScreenshot.configure { task =>
       task.setDescription(ExecuteScreenshotTests.description(flavor, buildType))
       task.flavor = flavor
-      task.buildType = buildType
+      task.buildTypeName = buildType.getName
       task.appId = appId
       task.orchestrated = orchestrated
+      task.projectPath = project.getProjectDir.getAbsolutePath
+      task.buildPath = project.getBuildDir.getAbsolutePath
+      task.shotExtension = project.getExtensions.findByType(classOf[ShotExtension])
+      task.directorySuffix = if (project.hasProperty("directorySuffix")) Some(project.property("directorySuffix").toString)
+      else None
+      task.recordScreenshots = project.hasProperty("record")
+      task.printBase64 = project.hasProperty("printBase64")
+      task.projectName = project.getName
     }
 
     if (runInstrumentation(project, extension)) {

--- a/shot/src/main/scala/com/karumi/shot/tasks/Tasks.scala
+++ b/shot/src/main/scala/com/karumi/shot/tasks/Tasks.scala
@@ -19,18 +19,18 @@ import org.gradle.api.{DefaultTask, GradleException}
 import java.io.File
 
 abstract class ShotTask extends DefaultTask {
-  var appId: String          = _
-  var flavor: Option[String] = _
-  var buildTypeName: String   = _
-  var orchestrated: Boolean  = false
-  var projectPath: String    = _
-  var buildPath: String      = _
-  var shotExtension: ShotExtension = _
+  var appId: String                   = _
+  var flavor: Option[String]          = _
+  var buildTypeName: String           = _
+  var orchestrated: Boolean           = false
+  var projectPath: String             = _
+  var buildPath: String               = _
+  var shotExtension: ShotExtension    = _
   var directorySuffix: Option[String] = _
-  var recordScreenshots: Boolean = _
-  var printBase64: Boolean = _
-  var projectName: String = _
-  private val console        = new Console
+  var recordScreenshots: Boolean      = _
+  var printBase64: Boolean            = _
+  var projectName: String             = _
+  private val console                 = new Console
   protected val shot: Shot =
     new Shot(
       new Adb,
@@ -80,7 +80,7 @@ class ExecuteScreenshotTests extends ShotTask {
 
   @TaskAction
   def executeScreenshotTests(): Unit = {
-    val tolerance = shotExtension.tolerance
+    val tolerance                     = shotExtension.tolerance
     val showOnlyFailingTestsInReports = shotExtension.showOnlyFailingTestsInReports
     if (recordScreenshots) {
       shot.recordScreenshots(appId, shotFolder, orchestrated)


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #263

### :tophat: What is the goal?

Support Gradle configuration cache. 

### How is it being implemented?

* Avoid using project during task execution. Add extra parameters instead.
* Don't use BuildType as parameter. Use directly buildTypeName as parameter instead.

### How can it be tested?

Ideally, I could enable configuration cache in `shot-consumer` project, but this requires to update AGP and Gradle. ~~Should I do the update? Do you prefer that I do it as current PR or as separate PR?~~ I see that there is a pending PR with an update. #288 

### Disclaimer

I don't know Scala. All changes were done just by following current code. Please keep that in mind during code review.

PS. BTW, having Kotlin as programming language would enable much more people to contribute.

