### PR TITLE
Add screenshot name to test report

### DIFF
--- a/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
+++ b/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
@@ -130,12 +130,14 @@ class ExecutionReporter {
         val reason       = generateReasonMessage(error)
         val color        = if (isFailedTest) "red-text" else "green-text"
         val id           = screenshot.name.replace(".", "")
+        val screenshotName = screenshot.name
 
         if (showOnlyFailingTestsInReports && isFailedTest || !showOnlyFailingTestsInReports) {
           "<tr>" +
             s"<th><a href='#$id'>$result</a></th>" +
             s"<th><a href='#$id'><p class='$color'>Test class: $testClass</p>" +
             s"<p class='$color'>Test name: $testName</p></a></th>" +
+            s"<p class='$color'>Screenshot name: $screenshotName</p></th>" +
             s"<th>$reason</th>" +
             "</tr>"
         } else {
@@ -164,11 +166,13 @@ class ExecutionReporter {
         val color = if (isFailedTest) "red-text" else "green-text"
         val width = (screenshot.screenshotDimension.width * 0.2).toInt
         val id    = screenshot.name.replace(".", "")
+        val screenshotName = screenshot.name
 
         if (showOnlyFailingTestsInReports && isFailedTest || !showOnlyFailingTestsInReports) {
           "<tr>" +
             s"<th id='$id'> <p class='$color'>Test class: $testClass</p>" +
             s"<p class='$color'>Test name: $testName</p></th>" +
+            s"<p class='$color'>Screenshot name: $screenshotName</p></th>" +
             s"<th> <a href='$originalScreenshot'><img width='$width' src='$originalScreenshot'/></a></th>" +
             s"<th> <a href='$newScreenshot'><img width='$width' src='$newScreenshot'/></a></th>" +
             s"<th> <a href='$diff'><img width='$width' src='$diff'/></a></th>" +

--- a/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
+++ b/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
@@ -74,7 +74,7 @@ class ExecutionReporter {
         val testName           = screenshot.testName
         val originalScreenshot = "./images/recorded/" + screenshot.name + ".png"
         val width              = (screenshot.screenshotDimension.width * 0.2).toInt
-        val screenshotName = screenshot.name
+        val screenshotName     = screenshot.name
         "<tr>" +
           s"<th> <p>Test class: $testClass</p>" +
           s"<p>Test name: $testName</p></th>" +
@@ -123,13 +123,13 @@ class ExecutionReporter {
   ): String = {
     getSortedByResultScreenshots(comparision)
       .map { case (screenshot, error) =>
-        val isFailedTest = error.isDefined
-        val testClass    = screenshot.testClass
-        val testName     = screenshot.testName
-        val result       = if (isFailedTest) "❌" else "✅"
-        val reason       = generateReasonMessage(error)
-        val color        = if (isFailedTest) "red-text" else "green-text"
-        val id           = screenshot.name.replace(".", "")
+        val isFailedTest   = error.isDefined
+        val testClass      = screenshot.testClass
+        val testName       = screenshot.testName
+        val result         = if (isFailedTest) "❌" else "✅"
+        val reason         = generateReasonMessage(error)
+        val color          = if (isFailedTest) "red-text" else "green-text"
+        val id             = screenshot.name.replace(".", "")
         val screenshotName = screenshot.name
 
         if (showOnlyFailingTestsInReports && isFailedTest || !showOnlyFailingTestsInReports) {
@@ -163,9 +163,9 @@ class ExecutionReporter {
         } else {
           ""
         }
-        val color = if (isFailedTest) "red-text" else "green-text"
-        val width = (screenshot.screenshotDimension.width * 0.2).toInt
-        val id    = screenshot.name.replace(".", "")
+        val color          = if (isFailedTest) "red-text" else "green-text"
+        val width          = (screenshot.screenshotDimension.width * 0.2).toInt
+        val id             = screenshot.name.replace(".", "")
         val screenshotName = screenshot.name
 
         if (showOnlyFailingTestsInReports && isFailedTest || !showOnlyFailingTestsInReports) {

--- a/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
+++ b/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
@@ -74,9 +74,11 @@ class ExecutionReporter {
         val testName           = screenshot.testName
         val originalScreenshot = "./images/recorded/" + screenshot.name + ".png"
         val width              = (screenshot.screenshotDimension.width * 0.2).toInt
+        val screenshotName = screenshot.name
         "<tr>" +
           s"<th> <p>Test class: $testClass</p>" +
           s"<p>Test name: $testName</p></th>" +
+          s"<p>Screenshot name: $screenshotName</p></th>" +
           s"<th> <a href='$originalScreenshot'><img width='$width' src='$originalScreenshot'/></a></th>" +
           "</tr>"
       }


### PR DESCRIPTION
In the case of a screenshot test taking multiple screenshots per test it would be useful to have the name of the screenshot displayed in the test report. This PR adds this small change.