### PR TITLE
[ISSUE-284] Don't override screenshots when running multiple devices

### DIFF
--- a/core/src/main/scala/com/karumi/shot/Shot.scala
+++ b/core/src/main/scala/com/karumi/shot/Shot.scala
@@ -215,7 +215,6 @@ class Shot(
     forEachDevice { device =>
       val screenshotsFolder = shotFolder.screenshotsFolder()
       createScreenshotsFolderIfDoesNotExist(screenshotsFolder)
-      removeProjectTemporalScreenshotsFolder(shotFolder)
       adb.pullScreenshots(device, screenshotsFolder, appId, orchestrated)
 
       extractPicturesFromBundle(shotFolder.pulledScreenshotsFolder())


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Fixes #284

### :tophat: What is the goal?

When running screenshot tests on multiple devices, we want all the screenshots for all devices and not only the latest.
### How is it being implemented?

Stop deleting the screenshot folder on each device, it is already deleted after the task is finished so it's not needed.

### How can it be tested?

- [x] **Use case 1:** Connect 2 or more devices, run `./gradlew executeScreenshotTests` in shot-consumer 

