### PR TITLE
Support configuration cache (second attempt)

### DIFF
--- a/core/src/main/scala/com/karumi/shot/Shot.scala
+++ b/core/src/main/scala/com/karumi/shot/Shot.scala
@@ -35,10 +35,6 @@ class Shot(
     consoleReporter: ConsoleReporter,
     envVars: EnvVars
 ) {
-  def configureAdbPath(adbPath: Folder): Unit = {
-    Adb.adbBinaryPath = adbPath
-  }
-
   def downloadScreenshots(appId: AppId, shotFolder: ShotFolder, orchestrated: Boolean): Unit = {
     console.show("⬇️  Pulling screenshots from your connected devices!")
     pullScreenshots(appId, shotFolder, orchestrated)

--- a/core/src/main/scala/com/karumi/shot/android/Adb.scala
+++ b/core/src/main/scala/com/karumi/shot/android/Adb.scala
@@ -6,14 +6,15 @@ import com.karumi.shot.domain.model.{AppId, Folder}
 import scala.sys.process._
 
 object Adb {
-  var adbBinaryPath: String = ""
   // To be able to support API 29+ with scoped storage we need to change
   // the base url where the app saves our screenshots inside the device.
   // This value is computed in runtime in shot-android AndroidStorageInfo.
   private val baseStoragePath = "/storage/emulated/0/Download"
 }
 
-class Adb {
+class Adb(
+    adbPath: String
+) {
 
   private final val CR_ASCII_DECIMAL = 13
   private val logger = ProcessLogger(
@@ -94,10 +95,10 @@ class Adb {
   }
 
   private def executeAdbCommand(command: String): Int =
-    s"${Adb.adbBinaryPath} $command" ! logger
+    s"${adbPath} $command" ! logger
 
   private def executeAdbCommandWithResult(command: String): String =
-    s"${Adb.adbBinaryPath} $command" !! logger
+    s"${adbPath} $command" !! logger
 
   private def isCarriageReturnASCII(device: String): Boolean =
     device.charAt(0) == CR_ASCII_DECIMAL

--- a/core/src/test/scala/com/karumi/shot/ShotSpec.scala
+++ b/core/src/test/scala/com/karumi/shot/ShotSpec.scala
@@ -128,14 +128,6 @@ class ShotSpec
     )
   }
 
-  it should "configure adb path" in {
-    val anyAdbPath = "/Library/androidsdk/bin/adb"
-
-    shot.configureAdbPath(anyAdbPath)
-
-    Adb.adbBinaryPath shouldBe anyAdbPath
-  }
-
   it should "should delegate screenshots cleaning to Adb using the specified ANDROID_SERIAL env var" in {
     val appId: AppId          = AppIdMother.anyAppId
     val device1: String       = "emulator-5554"

--- a/shot/src/main/scala/com/karumi/shot/tasks/Tasks.scala
+++ b/shot/src/main/scala/com/karumi/shot/tasks/Tasks.scala
@@ -13,27 +13,28 @@ import com.karumi.shot.screenshots.{
 import com.karumi.shot.system.EnvVars
 import com.karumi.shot.ui.Console
 import com.karumi.shot.{Files, Shot, ShotExtension}
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.{Input, TaskAction}
 import org.gradle.api.{DefaultTask, GradleException}
 
 import java.io.File
 
 abstract class ShotTask extends DefaultTask {
-  var appId: String                   = _
-  var flavor: Option[String]          = _
-  var buildTypeName: String           = _
-  var orchestrated: Boolean           = false
-  var projectPath: String             = _
-  var buildPath: String               = _
-  var shotExtension: ShotExtension    = _
-  var directorySuffix: Option[String] = _
-  var recordScreenshots: Boolean      = _
-  var printBase64: Boolean            = _
-  var projectName: String             = _
-  private val console                 = new Console
-  protected val shot: Shot =
+  @Input var appId: String                   = _
+  @Input var flavor: Option[String]          = _
+  @Input var buildTypeName: String           = _
+  @Input var orchestrated: Boolean           = false
+  @Input var projectPath: String             = _
+  @Input var buildPath: String               = _
+  @Input var shotExtension: ShotExtension    = _
+  @Input var directorySuffix: Option[String] = _
+  @Input var recordScreenshots: Boolean      = _
+  @Input var printBase64: Boolean            = _
+  @Input var projectName: String             = _
+  @Input var adbPath: String                 = _
+  protected def shot: Shot = {
+    val console = new Console
     new Shot(
-      new Adb,
+      new Adb(adbPath),
       new Files,
       new ScreenshotsComparator,
       new ScreenshotsDiffGenerator(new Base64Encoder),
@@ -43,6 +44,7 @@ abstract class ShotTask extends DefaultTask {
       new ConsoleReporter(console),
       new EnvVars()
     )
+  }
 
   protected def shotFolder: ShotFolder = {
     ShotFolder(


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://github.com/pedrovgs/Shot/issues/263
* **Related pull-requests:**https://github.com/pedrovgs/Shot/pull/291

### :tophat: What is the goal?

Ensure that configuration cache works after Gradle daemon is recreated.

### How is it being implemented?

* Avoid using global variable because Gradle has no idea about it and cannot recreate when configuration cache is reused. Use explicit task input instead.
* Annotate other task inputs.
* Convert internal "shot" property to function. It's used only once by each task anyway.

### How can it be tested?

* `./gradlew debugExecuteScreenshotTests --configuration-cache`
* `./gradlew --stop`
* `./gradlew debugExecuteScreenshotTests --configuration-cache` - should display "Reusing configuration cache."
