### PR TITLE
Flush awt images

### DIFF
--- a/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotComposer.scala
+++ b/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotComposer.scala
@@ -25,7 +25,10 @@ object ScreenshotComposer {
         val part      = Image.fromFile(partFile).awt
         val xPosition = x * tileSize
         val yPosition = y * tileSize
-        composedImage = composedImage.overlay(new AwtImage(part), xPosition, yPosition)
+        val newComposedImage = composedImage.overlay(new AwtImage(part), xPosition, yPosition)
+        composedImage.awt.flush()
+        part.flush()
+        composedImage = newComposedImage
         partIndex += 1
       }
       composedImage

--- a/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsComparator.scala
+++ b/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsComparator.scala
@@ -22,18 +22,22 @@ class ScreenshotsComparator {
     if (!recordedScreenshotFile.exists()) {
       Some(ScreenshotNotFound(screenshot))
     } else {
-      val oldScreenshot =
-        Image.fromFile(recordedScreenshotFile)
+      val oldScreenshot = Image.fromFile(recordedScreenshotFile)
       val newScreenshot = ScreenshotComposer.composeNewScreenshot(screenshot)
-      if (!haveSameDimensions(newScreenshot, oldScreenshot)) {
-        val originalDimension =
-          Dimension(oldScreenshot.width, oldScreenshot.height)
-        val newDimension = Dimension(newScreenshot.width, newScreenshot.height)
-        Some(DifferentImageDimensions(screenshot, originalDimension, newDimension))
-      } else if (imagesAreDifferent(screenshot, oldScreenshot, newScreenshot, tolerance)) {
-        Some(DifferentScreenshots(screenshot))
-      } else {
-        None
+      try {
+        if (!haveSameDimensions(newScreenshot, oldScreenshot)) {
+          val originalDimension =
+            Dimension(oldScreenshot.width, oldScreenshot.height)
+          val newDimension = Dimension(newScreenshot.width, newScreenshot.height)
+          Some(DifferentImageDimensions(screenshot, originalDimension, newDimension))
+        } else if (imagesAreDifferent(screenshot, oldScreenshot, newScreenshot, tolerance)) {
+          Some(DifferentScreenshots(screenshot))
+        } else {
+          None
+        }
+      } finally {
+        oldScreenshot.awt.flush()
+        newScreenshot.awt.flush()
       }
     }
   }

--- a/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsDiffGenerator.scala
+++ b/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsDiffGenerator.scala
@@ -37,6 +37,9 @@ class ScreenshotsDiffGenerator(base64Encoder: Base64Encoder) {
     val diff              = newImage.composite(new RedComposite(1d), originalImage)
     val outputFilePath    = screenshot.getDiffScreenshotPath(outputFolder)
     diff.output(outputFilePath)
+    originalImage.awt.flush()
+    newImage.awt.flush()
+    diff.awt.flush()
     if (generateBase64Diff) {
       error.copy(base64Diff = base64Encoder.base64FromFile(outputFilePath))
     } else {

--- a/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsSaver.scala
+++ b/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsSaver.scala
@@ -72,7 +72,9 @@ class ScreenshotsSaver {
   ): Dimension = {
     val screenshotPath = shotFolder.pulledScreenshotsFolder() + screenshot.name + ".png"
     val image          = Image.fromFile(new File(screenshotPath))
-    Dimension(image.width, image.height)
+    val dimension      = Dimension(image.width, image.height)
+    image.awt.flush()
+    dimension
   }
 
   private def deleteOldTemporalScreenshots(projectName: String, shotFolder: ShotFolder): Unit = {
@@ -98,6 +100,7 @@ class ScreenshotsSaver {
       }
       val image = ScreenshotComposer.composeNewScreenshot(screenshot)
       image.output(outputFile)
+      image.awt.flush()
     }
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=5.14.1
+VERSION_NAME=5.14.1-fork2
 VERSION_CODE=501401
 GROUP=com.karumi
 POM_DESCRIPTION=Gradle plugin developed to facilitate screenshot testing for Android.


### PR DESCRIPTION
### :pushpin: References
* **Issue:** (https://github.com/pedrovgs/Shot/issues/304)
* **Related pull-requests:** _list of related pull-requests (comma-separated): #1, #2_

### :tophat: What is the goal?

To reduce OOM errors

### How is it being implemented?

Call flush on every created java.awt.BufferedImage

### How can it be tested?

Mostly when there's a lot of differences and/or big screenshots that need a lot of re-combination.

