### PR TITLE
Update jdk 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
       - name: Start emulator
         run: shot-consumer/scripts/start_emulator.sh
         timeout-minutes: 20
@@ -78,10 +74,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
       - name: Start emulator
         run: shot-consumer/scripts/start_emulator.sh
         timeout-minutes: 20
@@ -89,7 +81,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
           java-version: 17

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
       - name: Check code formatting
         run: ./gradlew clean checkScalaFmtAll ktlintCheck
       - name: Shot unit tests
@@ -85,6 +89,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
       - name: Disable artifacts signing
         run: echo "RELEASE_SIGNING_ENABLED=false" >> gradle.properties
       - name: Build and install Shot

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Shot unit tests
         run: ./gradlew :shot-android:connectedCheck
       - name: Disable artifacts signing
-        run: echo "RELEASE_SIGNING_ENABLED=false" >> gradle.properties
+        run: echo "\nRELEASE_SIGNING_ENABLED=false" >> gradle.properties
       - name: Build and install Shot
         run: ./gradlew publishToMavenLocal
       - name: Execute screenshot tests for shot-consumer-library-no-tests
@@ -86,7 +86,7 @@ jobs:
         with:
           java-version: 17
       - name: Disable artifacts signing
-        run: echo "RELEASE_SIGNING_ENABLED=false" >> gradle.properties
+        run: echo "\nRELEASE_SIGNING_ENABLED=false" >> gradle.properties
       - name: Build and install Shot
         run: ./gradlew publishToMavenLocal
       - name: Execute screenshot tests for shot-consumer-library-no-tests

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,12 @@ buildscript {
         google()
     }
 
-    ext.kotlin_version = "1.4.32"
+    ext.kotlin_version = "1.6.10"
 
     dependencies {
         classpath "gradle.plugin.com.github.maiflai:gradle-scalatest:0.31"
         classpath "gradle.plugin.cz.alenkacz:gradle-scalafmt:1.16.2"
-        classpath "com.android.tools.build:gradle:4.1.3"
+        classpath "com.android.tools.build:gradle:7.1.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:10.0.0"
         classpath 'com.vanniktech:gradle-maven-publish-plugin:0.15.1'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -13,10 +13,13 @@ repositories {
 dependencies {
     implementation 'org.scala-lang:scala-library:2.12.13'
     implementation 'org.scala-lang.modules:scala-xml_2.12:1.3.0'
-    implementation 'com.sksamuel.scrimage:scrimage-core_2.12:2.1.8'
+    implementation 'com.drewnoakes:metadata-extractor:2.18.0'
+    implementation 'com.sksamuel.scrimage:scrimage-core:4.0.31'
+    implementation 'com.sksamuel.scrimage:scrimage-scala_2.12:4.0.31'
     implementation 'io.github.bitstorm:tinyzip-core:1.0.0'
     implementation 'org.json4s:json4s-native_2.12:3.6.11'
     implementation 'org.json4s:json4s-jackson_2.12:3.6.11'
+    implementation 'commons-io:commons-io:2.11.0'
 
     testImplementation 'org.scalatest:scalatest_2.12:3.2.6'
     testRuntimeOnly "com.vladsch.flexmark:flexmark-profile-pegdown:0.36.8" // https://github.com/scalatest/scalatest/issues/1736

--- a/core/src/main/scala/com/karumi/shot/json/ScreenshotsComposeSuiteJsonParser.scala
+++ b/core/src/main/scala/com/karumi/shot/json/ScreenshotsComposeSuiteJsonParser.scala
@@ -1,6 +1,5 @@
 package com.karumi.shot.json
 
-import com.drew.metadata.Metadata
 import com.karumi.shot.domain.{Dimension, Screenshot}
 import com.karumi.shot.domain.model.{Folder, ScreenshotsSuite}
 import org.json4s._

--- a/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotComposer.scala
+++ b/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotComposer.scala
@@ -1,28 +1,28 @@
 package com.karumi.shot.screenshots
 
 import java.io.File
-
 import com.karumi.shot.domain.Screenshot
-import com.sksamuel.scrimage.{AwtImage, Color, Image}
+import com.sksamuel.scrimage.color.Colors
+import com.sksamuel.scrimage.{AwtImage, ImmutableImage}
 
 object ScreenshotComposer {
 
   private val tileSize = 512
 
-  private[screenshots] def composeNewScreenshot(screenshot: Screenshot): Image = {
+  private[screenshots] def composeNewScreenshot(screenshot: Screenshot): ImmutableImage = {
     val width  = screenshot.screenshotDimension.width
     val height = screenshot.screenshotDimension.height
     if (screenshot.recordedPartsPaths.size == 1) {
-      Image.fromFile(new File(screenshot.recordedPartsPaths.head))
+      ImmutableImage.loader().fromFile(new File(screenshot.recordedPartsPaths.head))
     } else {
-      var composedImage = Image.filled(width, height, Color.Transparent)
+      var composedImage = ImmutableImage.filled(width, height, Colors.Transparent.toAWT)
       var partIndex     = 0
       for (
         x <- 0 until screenshot.tilesDimension.width;
         y <- 0 until screenshot.tilesDimension.height
       ) {
         val partFile  = new File(screenshot.recordedPartsPaths(partIndex))
-        val part      = Image.fromFile(partFile).awt
+        val part      = ImmutableImage.loader().fromFile(partFile).awt
         val xPosition = x * tileSize
         val yPosition = y * tileSize
         composedImage = composedImage.overlay(new AwtImage(part), xPosition, yPosition)

--- a/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsComparator.scala
+++ b/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsComparator.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import com.karumi.shot.domain._
 import com.karumi.shot.domain.model.ScreenshotsSuite
-import com.sksamuel.scrimage.Image
+import com.sksamuel.scrimage.ImmutableImage
 
 class ScreenshotsComparator {
 
@@ -23,7 +23,7 @@ class ScreenshotsComparator {
       Some(ScreenshotNotFound(screenshot))
     } else {
       val oldScreenshot =
-        Image.fromFile(recordedScreenshotFile)
+        ImmutableImage.loader().fromFile(recordedScreenshotFile)
       val newScreenshot = ScreenshotComposer.composeNewScreenshot(screenshot)
       if (!haveSameDimensions(newScreenshot, oldScreenshot)) {
         val originalDimension =
@@ -40,8 +40,8 @@ class ScreenshotsComparator {
 
   private def imagesAreDifferent(
       screenshot: Screenshot,
-      oldScreenshot: Image,
-      newScreenshot: Image,
+      oldScreenshot: ImmutableImage,
+      newScreenshot: ImmutableImage,
       tolerance: Double
   ) = {
     if (oldScreenshot == newScreenshot) {
@@ -67,7 +67,7 @@ class ScreenshotsComparator {
     }
   }
 
-  private def haveSameDimensions(newScreenshot: Image, recordedScreenshot: Image): Boolean =
+  private def haveSameDimensions(newScreenshot: ImmutableImage, recordedScreenshot: ImmutableImage): Boolean =
     newScreenshot.width == recordedScreenshot.width && newScreenshot.height == recordedScreenshot.height
 
 }

--- a/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsComparator.scala
+++ b/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsComparator.scala
@@ -67,7 +67,10 @@ class ScreenshotsComparator {
     }
   }
 
-  private def haveSameDimensions(newScreenshot: ImmutableImage, recordedScreenshot: ImmutableImage): Boolean =
+  private def haveSameDimensions(
+      newScreenshot: ImmutableImage,
+      recordedScreenshot: ImmutableImage
+  ): Boolean =
     newScreenshot.width == recordedScreenshot.width && newScreenshot.height == recordedScreenshot.height
 
 }

--- a/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsDiffGenerator.scala
+++ b/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsDiffGenerator.scala
@@ -1,12 +1,12 @@
 package com.karumi.shot.screenshots
 
 import java.io.File
-
 import com.karumi.shot.base64.Base64Encoder
 import com.karumi.shot.domain.model.ScreenshotComparisionErrors
 import com.karumi.shot.domain.{DifferentScreenshots, ScreenshotsComparisionResult}
-import com.sksamuel.scrimage.Image
+import com.sksamuel.scrimage.ImmutableImage
 import com.sksamuel.scrimage.composite.RedComposite
+import com.sksamuel.scrimage.nio.PngWriter
 
 class ScreenshotsDiffGenerator(base64Encoder: Base64Encoder) {
 
@@ -32,11 +32,11 @@ class ScreenshotsDiffGenerator(base64Encoder: Base64Encoder) {
     val screenshot        = error.screenshot
     val originalImagePath = screenshot.recordedScreenshotPath
     val newImagePath      = screenshot.temporalScreenshotPath
-    val originalImage     = Image.fromFile(new File(originalImagePath))
-    val newImage          = Image.fromFile(new File(newImagePath))
+    val originalImage     = ImmutableImage.loader().fromFile(new File(originalImagePath))
+    val newImage          = ImmutableImage.loader().fromFile(new File(newImagePath))
     val diff              = newImage.composite(new RedComposite(1d), originalImage)
     val outputFilePath    = screenshot.getDiffScreenshotPath(outputFolder)
-    diff.output(outputFilePath)
+    diff.output(PngWriter.NoCompression, outputFilePath)
     if (generateBase64Diff) {
       error.copy(base64Diff = base64Encoder.base64FromFile(outputFilePath))
     } else {

--- a/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsSaver.scala
+++ b/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsSaver.scala
@@ -1,18 +1,10 @@
 package com.karumi.shot.screenshots
 
 import java.io.File
-import com.karumi.shot.domain.{
-  Config,
-  DifferentImageDimensions,
-  DifferentScreenshots,
-  Dimension,
-  Screenshot,
-  ScreenshotNotFound,
-  ScreenshotsComparisionResult,
-  ShotFolder
-}
+import com.karumi.shot.domain.{Dimension, Screenshot, ScreenshotsComparisionResult, ShotFolder}
 import com.karumi.shot.domain.model.{FilePath, Folder, ScreenshotsSuite}
-import com.sksamuel.scrimage.Image
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.nio.PngWriter
 import org.apache.commons.io.FileUtils
 
 class ScreenshotsSaver {
@@ -71,7 +63,7 @@ class ScreenshotsSaver {
       screenshot: Screenshot
   ): Dimension = {
     val screenshotPath = shotFolder.pulledScreenshotsFolder() + screenshot.name + ".png"
-    val image          = Image.fromFile(new File(screenshotPath))
+    val image          = ImmutableImage.loader().fromFile(new File(screenshotPath))
     Dimension(image.width, image.height)
   }
 
@@ -97,7 +89,7 @@ class ScreenshotsSaver {
         outputFile.createNewFile()
       }
       val image = ScreenshotComposer.composeNewScreenshot(screenshot)
-      image.output(outputFile)
+      image.output(PngWriter.NoCompression, outputFile)
     }
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,4 @@ POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_DEVELOPER_ID=pedrovgs
 POM_DEVELOPER_NAME=Pedro Vicente Gomez Sanchez
-
 android.useAndroidX=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,5 @@ POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_DEVELOPER_ID=pedrovgs
 POM_DEVELOPER_NAME=Pedro Vicente Gomez Sanchez
+
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/shot-android/build.gradle
+++ b/shot-android/build.gradle
@@ -4,12 +4,12 @@ apply plugin: "org.jlleitschuh.gradle.ktlint"
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion 28
+    compileSdk 32
     testOptions.unitTests.includeAndroidResources = true
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "com.karumi.shot.DexOpenerJUnitRunner"
@@ -38,22 +38,15 @@ repositories {
     mavenLocal()
     google()
     maven { url 'https://jitpack.io' }
-    exclusiveContent {
-        forRepository { jcenter() }
-        filter {
-            includeModule("org.jetbrains.kotlinx", "kotlinx-collections-immutable-jvm")
-            includeGroup("org.jetbrains.trove4j")
-        }
-    }
 }
 
 dependencies {
     implementation "com.facebook.testing.screenshot:core:0.14.0"
-    implementation "androidx.test:runner:1.3.0"
-    implementation "androidx.recyclerview:recyclerview:1.2.0"
-    implementation "androidx.test.espresso:espresso-core:3.3.0"
-    implementation "androidx.compose.ui:ui-test-junit4:1.0.0-beta03"
-    implementation "com.google.code.gson:gson:2.8.6"
+    implementation "androidx.test:runner:1.4.0"
+    implementation "androidx.recyclerview:recyclerview:1.2.1"
+    implementation "androidx.test.espresso:espresso-core:3.4.0"
+    implementation "androidx.compose.ui:ui-test-junit4:1.2.1"
+    implementation "com.google.code.gson:gson:2.8.8"
 
     // fragment-testing dependency is normally declared for debug (not test) sources,
     // as you'd usually run your FragmentScenario tests only in debug variants.
@@ -61,28 +54,29 @@ dependencies {
     // debugImplementation instead. However it doesn't matter here because we're still only using it
     // for testing purposes. FragmentScenario API is needed to provide waitForFragment() extension.
     //noinspection FragmentGradleConfiguration
-    implementation "androidx.fragment:fragment-testing:1.3.2"
+    implementation "androidx.fragment:fragment-testing:1.4.1"
 
     testImplementation "junit:junit:4.13.2"
-    testImplementation "org.mockito:mockito-core:3.9.0"
+    testImplementation "org.mockito:mockito-core:4.3.1"
     testImplementation "com.nhaarman:mockito-kotlin:1.6.0"
-    testImplementation "org.robolectric:robolectric:4.5.1"
-    testImplementation "androidx.test.ext:junit:1.1.2"
-    testImplementation "androidx.test:runner:1.3.0"
-    testImplementation "androidx.test:rules:1.3.0"
-    testImplementation "androidx.test.espresso:espresso-core:3.3.0"
-    testImplementation "androidx.test.espresso:espresso-intents:3.3.0"
-    testImplementation "androidx.test.espresso:espresso-contrib:3.3.0"
+    testImplementation "org.robolectric:robolectric:4.7.3"
+    testImplementation "androidx.test.ext:junit:1.1.3"
+    testImplementation "androidx.test:runner:1.4.0"
+    testImplementation "androidx.test:rules:1.4.0"
+    testImplementation "androidx.test.espresso:espresso-core:3.4.0"
+    testImplementation "androidx.test.espresso:espresso-intents:3.4.0"
+    testImplementation "androidx.test.espresso:espresso-contrib:3.4.0"
 
     androidTestImplementation "com.github.tmurakami:dexopener:2.0.5"
-    androidTestImplementation "org.mockito:mockito-android:2.28.2"
+    androidTestImplementation "org.mockito:mockito-android:4.3.1"
+    androidTestImplementation "org.mockito.kotlin:mockito-kotlin:4.1.0"
     androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
-    androidTestImplementation "androidx.test:runner:1.3.0"
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"
-    androidTestImplementation "androidx.test.espresso:espresso-intents:3.3.0"
-    androidTestImplementation "androidx.test.espresso:espresso-contrib:3.3.0"
-    androidTestImplementation "androidx.test:rules:1.3.0"
-    androidTestImplementation "androidx.test.ext:junit:1.1.2"
+    androidTestImplementation "androidx.test:runner:1.4.0"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.4.0"
+    androidTestImplementation "androidx.test.espresso:espresso-intents:3.4.0"
+    androidTestImplementation "androidx.test.espresso:espresso-contrib:3.4.0"
+    androidTestImplementation "androidx.test:rules:1.4.0"
+    androidTestImplementation "androidx.test.ext:junit:1.1.3"
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {

--- a/shot-consumer-compose/build.gradle
+++ b/shot-consumer-compose/build.gradle
@@ -1,17 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = '1.0.0-beta03'
+        compose_version = '1.0.0'
     }
-    ext.kotlin_version = "1.4.31"
+    ext.kotlin_version = "1.6.10"
     repositories {
         google()
-        jcenter()
         mavenLocal()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0-alpha12'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.karumi:shot:5.14.1"
     }
@@ -20,7 +19,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenLocal()
         mavenCentral()
     }

--- a/shot-consumer-flavors/app/build.gradle
+++ b/shot-consumer-flavors/app/build.gradle
@@ -4,7 +4,6 @@ buildscript {
         mavenLocal()
         mavenCentral()
         maven { url "https://jitpack.io" }
-        jcenter()
         google()
     }
     dependencies {

--- a/shot-consumer-flavors/build.gradle
+++ b/shot-consumer-flavors/build.gradle
@@ -1,12 +1,11 @@
 buildscript {
-    ext.kotlin_version = '1.4.21'
+    ext.kotlin_version = '1.6.10'
     repositories {
         mavenLocal()
         google()
-        jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.0-beta01"
+        classpath "com.android.tools.build:gradle:7.1.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.karumi:shot:5.14.1"
     }
@@ -16,7 +15,6 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
         maven { url "https://jitpack.io" }
     }
 }

--- a/shot-consumer-library-no-tests/build.gradle.kts
+++ b/shot-consumer-library-no-tests/build.gradle.kts
@@ -6,8 +6,8 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath("com.android.tools.build:gradle:7.1.0-alpha06")
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21")
+    classpath("com.android.tools.build:gradle:7.1.2")
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
     classpath("com.karumi:shot:5.14.1")
 
     // NOTE: Do not place your application dependencies here; they belong

--- a/shot-consumer-library-no-tests/settings.gradle.kts
+++ b/shot-consumer-library-no-tests/settings.gradle.kts
@@ -4,7 +4,6 @@ dependencyResolutionManagement {
     mavenLocal()
     google()
     mavenCentral()
-    jcenter() // Warning: this repository is going to shut down soon
   }
 }
 rootProject.name = "ShotAGPBug"

--- a/shot-consumer/app/build.gradle
+++ b/shot-consumer/app/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     mavenLocal()
     mavenCentral()
     maven { url "https://jitpack.io" }
-    jcenter()
     google()
   }
   dependencies {

--- a/shot-consumer/app2/build.gradle
+++ b/shot-consumer/app2/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     mavenLocal()
     mavenCentral()
     maven { url "https://jitpack.io" }
-    jcenter()
     google()
   }
   dependencies {

--- a/shot-consumer/build.gradle
+++ b/shot-consumer/build.gradle
@@ -1,13 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.4.21'
+    ext.kotlin_version = '1.6.10'
     repositories {
         mavenLocal()
         mavenCentral()
         google()
-        jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.0-alpha01"
+        classpath "com.android.tools.build:gradle:7.1.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.karumi:shot:5.14.1"
     }
@@ -18,7 +17,6 @@ allprojects {
         mavenLocal()
         mavenCentral()
         google()
-        jcenter()
         maven { url "https://jitpack.io" }
     }
 }

--- a/shot/build.gradle
+++ b/shot/build.gradle
@@ -9,20 +9,15 @@ repositories {
     mavenCentral()
     mavenLocal()
     google()
-    exclusiveContent {
-        forRepository { jcenter() }
-        filter {
-            includeGroup("org.jetbrains.trove4j")
-        }
-    }
 }
 
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
     implementation project(':core')
-    compileOnly 'com.android.tools.build:gradle:7.1.0-alpha06'
+    compileOnly 'com.android.tools.build:gradle:7.1.2'
     implementation 'org.scala-lang:scala-library:2.12.13'
+    implementation 'commons-io:commons-io:2.11.0'
 
     testImplementation 'org.scalatest:scalatest_2.12:3.2.6'
     testRuntimeOnly "com.vladsch.flexmark:flexmark-profile-pegdown:0.36.8" // https://github.com/scalatest/scalatest/issues/1736


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  #287 
* **Related pull-requests:** #292 

### :tophat: What is the goal?
AGP 7.4.0 requires plugins to target JDK 11, update shot to enable environments running latest versions

Based on #292, rebased on master and ran tests

### How is it being implemented?
Checkout original PR

### How can it be tested?

- Set your JDK to version 17+  (Can be done by settinh JAVA_HOME environment variable or through IDE settings)
- Publish all artefacts to maven local
- Run shot commands from a host application (shot-consumer projects can be used)