### PR TITLE
Ensure UTF-8 Charset for Verification HTML

### DIFF
--- a/core/src/main/scala/com/karumi/shot/templates/VerificationIndexTemplate.scala
+++ b/core/src/main/scala/com/karumi/shot/templates/VerificationIndexTemplate.scala
@@ -11,11 +11,11 @@ object VerificationIndexTemplate {
     s"""
 <!doctype html>
 <html>
-<meta charset="UTF-8">
 <head>
     <title>Shot verification results</title>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <meta charset="UTF-8">
 </head>
 <style>
     body {

--- a/core/src/main/scala/com/karumi/shot/templates/VerificationIndexTemplate.scala
+++ b/core/src/main/scala/com/karumi/shot/templates/VerificationIndexTemplate.scala
@@ -11,6 +11,7 @@ object VerificationIndexTemplate {
     s"""
 <!doctype html>
 <html>
+<meta charset="UTF-8">
 <head>
     <title>Shot verification results</title>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css" rel="stylesheet">


### PR DESCRIPTION
The emojis used in the verification template such as "❌" and "✅" are not rendered properly if the default charset of the OS is not UTF-8, ie a Windows machine may default to "Windows-1252" charset where the emojis aren't rendered. This is avoided by just specifying the charset in the meta tag in the HTML directly